### PR TITLE
Added previously missing data to language.lua alongside with a few changes.

### DIFF
--- a/src/lexer/language.lua
+++ b/src/lexer/language.lua
@@ -143,7 +143,7 @@ return {
 
 	libraries = {
 
-		-- Lua Libraries
+		-- Luau Libraries
 		math = {
 			abs = true,
 			acos = true,

--- a/src/lexer/language.lua
+++ b/src/lexer/language.lua
@@ -27,9 +27,8 @@ return {
 	},
 
 	builtin = {
-		-- Lua Functions
+		-- Luau Functions
 		["assert"] = true,
-		["collectgarbage"] = true,
 		["error"] = true,
 		["getfenv"] = true,
 		["getmetatable"] = true,
@@ -52,11 +51,14 @@ return {
 		["unpack"] = true,
 		["xpcall"] = true,
 
-		-- Lua Variables
+		-- Luau Functions (Deprecated)
+		["collectgarbage"] = true,
+
+		-- Luau Variables
 		["_G"] = true,
 		["_VERSION"] = true,
 
-		-- Lua Tables
+		-- Luau Tables
 		["bit32"] = true,
 		["coroutine"] = true,
 		["debug"] = true,
@@ -68,7 +70,6 @@ return {
 
 		-- Roblox Functions
 		["delay"] = true,
-		["elapsedTime"] = true,
 		["gcinfo"] = true,
 		["require"] = true,
 		["settings"] = true,
@@ -79,6 +80,13 @@ return {
 		["UserSettings"] = true,
 		["wait"] = true,
 		["warn"] = true,
+
+		-- Roblox Functions (Deprecated)
+		["Delay"] = true,
+		["ElapsedTime"] = true,
+		["elapsedTime"] = true,
+		["Spawn"] = true,
+		["Wait"] = true,
 		["ypcall"] = true,
 
 		-- Roblox Variables
@@ -88,6 +96,11 @@ return {
 		["script"] = true,
 		["workspace"] = true,
 		["plugin"] = true,
+		["File"] = true,
+
+		-- Roblox Variables (Deprecated)
+		["Game"] = true,
+		["Workspace"] = true,
 
 		-- Roblox Tables
 		["Axes"] = true,
@@ -101,7 +114,6 @@ return {
 		["DateTime"] = true,
 		["DockWidgetPluginGuiInfo"] = true,
 		["Faces"] = true,
-		["File"] = true,
 		["FloatCurveKey"] = true,
 		["Instance"] = true,
 		["NumberRange"] = true,


### PR DESCRIPTION
Since there doesn't seem to any new library additions to the Luau for v506 (At least there doesn't seem to be one for now, gonna wait for releases notes to come out first.), I decided to make changes to the comments and go through the autocomplete to add missing data down below, which includes:

Changing comments that includes "Lua" to "Luau",
Moved deprecated global members under separate comments.
Added following data to built-ins:
`Delay`
`ElapsedTime`
`elapsedTime`
`Spawn`
`Wait`
`Game`
`Workspace`