### PR TITLE
Add npm package for Nevermore consumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/boatbomber/Highlighter.git"
     },
     "contributors": [
-        "BoatBomber"
+        "boatbomber"
     ],
     "bugs": {
         "url": "https://github.com/boatbomber/Highlighter/issues"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@boatbomber/highlighter",
+    "version": "1.0.0",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/boatbomber/Highlighter.git"
+    },
+    "contributors": [
+        "BoatBomber"
+    ],
+    "bugs": {
+        "url": "https://github.com/boatbomber/Highlighter/issues"
+    }
+}


### PR DESCRIPTION
This allows the package to be installed via npm/git.

If you want to publish it to npm, you can run `npm publish` in command line to publish it. 