### PR TITLE
Expand language.lua data to include Roblox v524 changes.

### DIFF
--- a/src/lexer/language.lua
+++ b/src/lexer/language.lua
@@ -22,10 +22,10 @@ local language = {
 		["self"] = true,
 		["then"] = true,
 		["true"] = true,
-		["until"] = true,
-		["while"] = true,
 		["type"] = true,
 		["typeof"] = true
+		["until"] = true,
+		["while"] = true,
 	},
 
 	builtin = {
@@ -314,6 +314,7 @@ local language = {
 		CFrame = {
 			Angles = true,
 			fromAxisAngle = true,
+			fromEulerAngles = true,
 			fromEulerAnglesXYZ = true,
 			fromEulerAnglesYXZ = true,
 			fromMatrix = true,


### PR DESCRIPTION
This pull request implements the following changes to `language.lua`:

```diff
+CFrame.fromEulerAngles
```

Also updated the `type`/`typeof` entries to follow the alphabetical order.
Will keep this as a draft until release notes confirms it.