### PR TITLE
Update language.lua to include v547 changes.

### DIFF
--- a/src/lexer/language.lua
+++ b/src/lexer/language.lua
@@ -98,7 +98,6 @@ local language = {
 		["ypcall"] = true,
 
 		-- Roblox Variables
-		["File"] = true,
 		["game"] = true,
 		["plugin"] = true,
 		["script"] = true,
@@ -367,6 +366,8 @@ local language = {
 
 		Font = {
 			fromEnum = true,
+			fromId = true,
+			fromName = true,
 			new = true,
 		},
 


### PR DESCRIPTION
This pull request implements the following changes to `language.lua`:

```diff
+Font.fromId
+Font.fromName
-File
```

Note: `File` global was supposed to be removed from the list alongside with `TextChatMessageProperties` a long time ago but for unknown reasons I forgot to remove it up until now.

Will keep this as a draft until release notes confirms it (or not, they sometimes don't include it in release notes).