### PR TITLE
Update `language.lua` to include v569 changes

### DIFF
--- a/src/lexer/language.lua
+++ b/src/lexer/language.lua
@@ -179,6 +179,7 @@ local language = {
 
 		debug = {
 			dumpheap = "function",
+			getmemorycategory = "function",
 			info = "function",
 			loadmodule = "function",
 			profilebegin = "function",


### PR DESCRIPTION
Many apologies for the time it took to make this pull request. Here is the change log:
```diff
+debug.getmemorycategory
```