### PR TITLE
`navigator:HotswapSource()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ type BuildRichTextLinesProps = {
 }
 
 type Lexer = {
-    scan: (src: string, start: number?) -> () -> (string, string),
+    scan: (src: string, startIndex: number?) -> () -> (string, string),
     navigator: () -> any,
     finished: boolean?,
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Roblox Model:
 
 Download from [Releases](https://github.com/boatbomber/Highlighter/releases)
 
-
 ## API
 
 **Functions:**
@@ -103,7 +102,7 @@ type BuildRichTextLinesProps = {
 }
 
 type Lexer = {
-    scan: (src: string) -> () -> (string, string),
+    scan: (src: string, start: number?) -> () -> (string, string),
     navigator: () -> any,
     finished: boolean?,
 }

--- a/src/lexer/init.lua
+++ b/src/lexer/init.lua
@@ -101,10 +101,10 @@ end
 
 --- Create a plain token iterator from a string.
 -- @tparam string s a string.
--- @tparam number? start a start index, assumed to be properly aligned to the tokens.
+-- @tparam number? startIndex a start index, assumed to be properly aligned to the tokens.
 
-function lexer.scan(s: string, start: number?)
-	local index = start or 1
+function lexer.scan(s: string, startIndex: number?)
+	local index = startIndex or 1
 	local size = #s
 	local previousContent1, previousContent2, previousContent3, previousToken = "", "", "", ""
 

--- a/src/lexer/init.lua
+++ b/src/lexer/init.lua
@@ -240,6 +240,16 @@ function lexer.navigator()
 		_ScanThread = nil,
 	}
 
+	function nav:_createScanThread(StartPosition)
+		self._ScanThread = coroutine.create(function()
+			for Token, Src in lexer.scan(self.Source, StartPosition) do
+				self._RealIndex += 1
+				self.TokenCache[self._RealIndex] = { Token, Src }
+				coroutine.yield(Token, Src)
+			end
+		end)
+	end
+
 	function nav:Destroy()
 		self.Source = nil
 		self._RealIndex = nil
@@ -255,13 +265,7 @@ function lexer.navigator()
 		self._UserIndex = 0
 		table.clear(self.TokenCache)
 
-		self._ScanThread = coroutine.create(function()
-			for Token, Src in lexer.scan(self.Source) do
-				self._RealIndex += 1
-				self.TokenCache[self._RealIndex] = { Token, Src }
-				coroutine.yield(Token, Src)
-			end
-		end)
+		self:_createScanThread()
 	end
 
 	function nav:HotswapSource(SourceString)
@@ -312,13 +316,7 @@ function lexer.navigator()
 		self._RealIndex = math.min(self._RealIndex, lastSharedTokenIndex)
 		self._UserIndex = 0
 
-		self._ScanThread = coroutine.create(function()
-			for Token, Src in lexer.scan(self.Source, sourceIndex) do
-				self._RealIndex += 1
-				self.TokenCache[self._RealIndex] = { Token, Src }
-				coroutine.yield(Token, Src)
-			end
-		end)
+		self:_createScanThread(sourceIndex)
 	end
 
 	function nav.Next()

--- a/src/lexer/init.lua
+++ b/src/lexer/init.lua
@@ -265,7 +265,19 @@ function lexer.navigator()
 	end
 
 	function nav:HotswapSource(newSource)
-		local oldSource = self.Source or ""
+		local oldSource = self.Source
+
+		if
+			not oldSource
+			or #oldSource == 0
+			or #newSource == 0
+			or string.byte(oldSource, 1) ~= string.byte(newSource, 1)
+		then
+			-- No common tokens to share, just set normally
+			self:SetSource(newSource)
+			return
+		end
+
 		self.Source = newSource
 
 		local minimumLength, maximumLength = 0, math.min(#oldSource, #newSource)

--- a/src/lexer/init.lua
+++ b/src/lexer/init.lua
@@ -264,29 +264,29 @@ function lexer.navigator()
 		end)
 	end
 
-	function nav:HotswapSource(newSource)
-		local oldSource = self.Source
+	function nav:HotswapSource(SourceString)
+		local previousSource = self.Source
 
 		if
-			not oldSource
-			or #oldSource == 0
-			or #newSource == 0
-			or string.byte(oldSource, 1) ~= string.byte(newSource, 1)
+			not previousSource
+			or #previousSource == 0
+			or #SourceString == 0
+			or string.byte(previousSource, 1) ~= string.byte(SourceString, 1)
 		then
 			-- No common tokens to share, just set normally
-			self:SetSource(newSource)
+			self:SetSource(SourceString)
 			return
 		end
 
-		self.Source = newSource
+		self.Source = SourceString
 
-		local minimumLength, maximumLength = 0, math.min(#oldSource, #newSource)
+		local minimumLength, maximumLength = 0, math.min(#previousSource, #SourceString)
 		while minimumLength < maximumLength do
 			local mid = (minimumLength + maximumLength + 1) // 2
 
 			if
-				oldSource:byte(mid) == newSource:byte(mid) -- cheap check of last character
-				and oldSource:sub(1, mid - 1) == newSource:sub(1, mid - 1) -- expensive check of all previous characters
+				string.byte(previousSource, mid) == string.byte(SourceString, mid) -- cheap check of last character
+				and string.sub(previousSource, 1, mid - 1) == string.sub(SourceString, 1, mid - 1) -- expensive check of all previous characters
 			then
 				minimumLength = mid
 			else

--- a/src/lexer/init.lua
+++ b/src/lexer/init.lua
@@ -299,15 +299,15 @@ function lexer.navigator()
 		end
 
 		local lastSharedTokenIndex = 0
-		local sourceIndex = 0
+		local sourcePosition = 0
 
 		-- find position of the last common token that is cached
 		for tokenIndex, cachedToken in self.TokenCache do
 			local sourceLength = #cachedToken[2]
 
-			if sourceIndex + sourceLength < minimumLength then
+			if sourcePosition + sourceLength <= minimumLength then
 				lastSharedTokenIndex = tokenIndex
-				sourceIndex += sourceLength
+				sourcePosition += sourceLength
 			else
 				break
 			end
@@ -321,7 +321,7 @@ function lexer.navigator()
 			self.TokenCache[index] = nil
 		end
 
-		self:_createScanThread(sourceIndex)
+		self:_createScanThread(sourcePosition + 1)
 	end
 
 	function nav.Next()

--- a/src/lexer/init.lua
+++ b/src/lexer/init.lua
@@ -316,6 +316,11 @@ function lexer.navigator()
 		self._RealIndex = math.min(self._RealIndex, lastSharedTokenIndex)
 		self._UserIndex = 0
 
+		-- clear outdated tokens from the cache
+		for index = self._RealIndex + 1, #self.TokenCache do
+			self.TokenCache[index] = nil
+		end
+
 		self:_createScanThread(sourceIndex)
 	end
 


### PR DESCRIPTION
Implements a new `navigator:HotswapSource()` function. It uses a binary search to find the longest common prefix of the current source and the previous source and only clears cached tokens that occur after said prefix.

It means that, if you were to use a `navigator` on something that continuously changes (i.e., a script in the script editor), it would discard much less work when the source is edited.

In some of my benchmarks on longer scripts (300 lines or so), it was reaching roughly a 10x speed increase!

It retains the behaviour of resetting the user index to zero, so would act as a 1:1 drop in replacement to `navigator:SetSource()`.

It also adds `start` parameter to `lexer.scan()` (this is utilised by `navigator:HotswapSource()` to skip the already cached tokens).